### PR TITLE
Add task approval workflow with role-based permissions

### DIFF
--- a/backend/domain/task.go
+++ b/backend/domain/task.go
@@ -9,28 +9,32 @@ import (
 type Status string
 
 const (
-	StatusDraft      Status = "draft"
-	StatusOpen       Status = "open"
-	StatusInProgress Status = "in_progress"
-	StatusDone       Status = "done"
+	StatusDraft            Status = "draft"
+	StatusOpen             Status = "open"
+	StatusInProgress       Status = "in_progress"
+	StatusPendingApproval  Status = "pending_approval"
+	StatusDone             Status = "done"
 )
 
 // Task is the core domain entity.
 type Task struct {
-	ID          string
-	Title       string
-	Description string
-	Status      Status
-	AssigneeID  string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID              string
+	Title           string
+	Description     string
+	Status          Status
+	AssigneeID      string
+	ApproverID      string
+	RejectionReason string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // validTransitions defines the allowed state machine edges.
 var validTransitions = map[Status][]Status{
-	StatusDraft:      {StatusOpen},
-	StatusOpen:       {StatusInProgress},
-	StatusInProgress: {StatusDone},
+	StatusDraft:           {StatusOpen},
+	StatusOpen:            {StatusInProgress},
+	StatusInProgress:      {StatusPendingApproval},
+	StatusPendingApproval: {StatusDone, StatusInProgress},
 }
 
 // Transition moves the task to newStatus if the transition is valid.
@@ -47,6 +51,31 @@ func (t *Task) Transition(newStatus Status) error {
 		}
 	}
 	return errors.New("invalid status transition: " + string(t.Status) + " -> " + string(newStatus))
+}
+
+// Approve transitions the task to done if it is pending approval.
+func (t *Task) Approve(approverID string) error {
+	if t.Status != StatusPendingApproval {
+		return errors.New("task must be pending approval to approve")
+	}
+	t.ApproverID = approverID
+	t.Status = StatusDone
+	t.UpdatedAt = time.Now()
+	return nil
+}
+
+// Reject returns the task to in_progress with a reason.
+func (t *Task) Reject(reason string) error {
+	if t.Status != StatusPendingApproval {
+		return errors.New("task must be pending approval to reject")
+	}
+	if reason == "" {
+		return errors.New("rejection reason is required")
+	}
+	t.RejectionReason = reason
+	t.Status = StatusInProgress
+	t.UpdatedAt = time.Now()
+	return nil
 }
 
 // Validate checks business invariants.

--- a/backend/handler/task_handler.go
+++ b/backend/handler/task_handler.go
@@ -67,3 +67,46 @@ func (h *TaskHandler) TransitionTask(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 }
+
+// ApproveTask handles POST /tasks/:id/approve.
+func (h *TaskHandler) ApproveTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	taskID := r.PathValue("id")
+	role := r.Header.Get("X-User-Role")
+	approverID := r.Header.Get("X-User-ID")
+
+	if err := h.service.ApproveTask(taskID, approverID, role); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// RejectTask handles POST /tasks/:id/reject.
+func (h *TaskHandler) RejectTask(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	taskID := r.PathValue("id")
+	var input struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.service.RejectTask(taskID, input.Reason); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -32,3 +32,13 @@ func RequireRole(allowed ...Role) func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// CanApprove checks whether a role has approval privileges.
+func CanApprove(role Role) bool {
+	return role == RoleLead || role == RoleAdmin
+}
+
+// RequireApprovalRole is a convenience middleware for approval endpoints.
+func RequireApprovalRole() func(http.Handler) http.Handler {
+	return RequireRole(RoleLead, RoleAdmin)
+}

--- a/backend/migrations/002_add_approval.sql
+++ b/backend/migrations/002_add_approval.sql
@@ -1,0 +1,10 @@
+-- Add approval workflow columns to tasks table
+ALTER TABLE tasks ADD COLUMN approver_id TEXT;
+ALTER TABLE tasks ADD COLUMN rejection_reason TEXT;
+ALTER TABLE tasks ADD COLUMN approved_at TIMESTAMP;
+
+-- Add pending_approval to the status check constraint
+-- (SQLite does not support ALTER CHECK, so this is for documentation)
+-- Valid statuses: draft, open, in_progress, pending_approval, done
+
+CREATE INDEX idx_tasks_pending_approval ON tasks(status) WHERE status = 'pending_approval';

--- a/backend/usecase/task_service.go
+++ b/backend/usecase/task_service.go
@@ -45,3 +45,41 @@ func (s *TaskService) TransitionStatus(id string, newStatus domain.Status) error
 	}
 	return s.repo.Save(task)
 }
+
+// SubmitForApproval moves a task to pending_approval status.
+func (s *TaskService) SubmitForApproval(id string) error {
+	return s.TransitionStatus(id, domain.StatusPendingApproval)
+}
+
+// ApproveTask approves a pending task.
+func (s *TaskService) ApproveTask(id string, approverID string, role string) error {
+	if role != "lead" && role != "admin" {
+		return errors.New("only lead or admin can approve tasks")
+	}
+	task, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+	if task == nil {
+		return errors.New("task not found")
+	}
+	if err := task.Approve(approverID); err != nil {
+		return err
+	}
+	return s.repo.Save(task)
+}
+
+// RejectTask rejects a pending task with a reason.
+func (s *TaskService) RejectTask(id string, reason string) error {
+	task, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+	if task == nil {
+		return errors.New("task not found")
+	}
+	if err := task.Reject(reason); err != nil {
+		return err
+	}
+	return s.repo.Save(task)
+}

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -21,3 +21,19 @@ export async function transitionTask(id: string, newStatus: string): Promise<voi
   });
   if (!res.ok) throw new Error("Failed to transition task");
 }
+
+export async function approveTask(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/tasks/${id}/approve`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error("Failed to approve task");
+}
+
+export async function rejectTask(id: string, reason: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/tasks/${id}/reject`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reason }),
+  });
+  if (!res.ok) throw new Error("Failed to reject task");
+}

--- a/frontend/src/components/ApprovalDialog.tsx
+++ b/frontend/src/components/ApprovalDialog.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+
+type ApprovalDialogProps = {
+  taskId: string;
+  taskTitle: string;
+  isOpen: boolean;
+  onApprove: (taskId: string) => void;
+  onReject: (taskId: string, reason: string) => void;
+  onClose: () => void;
+};
+
+export function ApprovalDialog({
+  taskId,
+  taskTitle,
+  isOpen,
+  onApprove,
+  onReject,
+  onClose,
+}: ApprovalDialogProps) {
+  const [rejectionReason, setRejectionReason] = useState("");
+  const [mode, setMode] = useState<"choose" | "reject">("choose");
+
+  if (!isOpen) return null;
+
+  const handleReject = () => {
+    if (rejectionReason.trim() === "") return;
+    onReject(taskId, rejectionReason);
+    setRejectionReason("");
+    setMode("choose");
+  };
+
+  return (
+    <div className="approval-dialog-overlay" role="dialog" aria-modal="true">
+      <div className="approval-dialog">
+        <h2>Review Task</h2>
+        <p>
+          <strong>{taskTitle}</strong>
+        </p>
+
+        {mode === "choose" ? (
+          <div className="approval-actions">
+            <button
+              className="btn-approve"
+              onClick={() => onApprove(taskId)}
+            >
+              Approve
+            </button>
+            <button
+              className="btn-reject"
+              onClick={() => setMode("reject")}
+            >
+              Reject
+            </button>
+            <button className="btn-cancel" onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="rejection-form">
+            <label htmlFor="rejection-reason">Rejection Reason</label>
+            <textarea
+              id="rejection-reason"
+              value={rejectionReason}
+              onChange={(e) => setRejectionReason(e.target.value)}
+              placeholder="Please provide a reason for rejection..."
+              rows={3}
+            />
+            <div className="rejection-actions">
+              <button
+                className="btn-confirm-reject"
+                onClick={handleReject}
+                disabled={rejectionReason.trim() === ""}
+              >
+                Confirm Rejection
+              </button>
+              <button className="btn-cancel" onClick={() => setMode("choose")}>
+                Back
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -7,18 +7,22 @@ type TaskCardProps = {
   status: string;
   assignee: string;
   onTransition?: (id: string, newStatus: string) => void;
+  onRequestApproval?: (id: string) => void;
 };
 
-export function TaskCard({ id, title, status, assignee, onTransition }: TaskCardProps) {
+export function TaskCard({ id, title, status, assignee, onTransition, onRequestApproval }: TaskCardProps) {
   return (
     <div className="task-card" data-testid={`task-${id}`}>
       <h3>{title}</h3>
       <StatusBadge status={status} />
       <p className="assignee">Assigned to: {assignee}</p>
-      {onTransition && status === "in_progress" && (
-        <button onClick={() => onTransition(id, "done")}>
-          Mark Done
+      {onRequestApproval && status === "in_progress" && (
+        <button onClick={() => onRequestApproval(id)}>
+          Submit for Approval
         </button>
+      )}
+      {status === "pending_approval" && (
+        <p className="pending-label">Awaiting approval</p>
       )}
     </div>
   );

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -1,19 +1,35 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { TaskCard } from "../components/TaskCard";
+import { ApprovalDialog } from "../components/ApprovalDialog";
 import { useTaskStore } from "../store/taskStore";
-import { fetchTasks, transitionTask } from "../api/tasks";
+import { fetchTasks, transitionTask, approveTask, rejectTask } from "../api/tasks";
 
 export function TaskBoard() {
   const { tasks, setTasks, updateTaskStatus } = useTaskStore();
+  const [approvalTarget, setApprovalTarget] = useState<string | null>(null);
 
   useEffect(() => {
     fetchTasks().then(setTasks);
   }, [setTasks]);
 
-  const handleTransition = async (id: string, newStatus: string) => {
-    await transitionTask(id, newStatus);
-    updateTaskStatus(id, newStatus);
+  const handleRequestApproval = async (id: string) => {
+    await transitionTask(id, "pending_approval");
+    updateTaskStatus(id, "pending_approval");
   };
+
+  const handleApprove = async (id: string) => {
+    await approveTask(id);
+    updateTaskStatus(id, "done");
+    setApprovalTarget(null);
+  };
+
+  const handleReject = async (id: string, reason: string) => {
+    await rejectTask(id, reason);
+    updateTaskStatus(id, "in_progress");
+    setApprovalTarget(null);
+  };
+
+  const targetTask = tasks.find((t) => t.id === approvalTarget);
 
   return (
     <div className="task-board">
@@ -26,10 +42,21 @@ export function TaskBoard() {
             title={task.title}
             status={task.status}
             assignee={task.assignee}
-            onTransition={handleTransition}
+            onRequestApproval={handleRequestApproval}
           />
         ))}
       </div>
+
+      {targetTask && (
+        <ApprovalDialog
+          taskId={targetTask.id}
+          taskTitle={targetTask.title}
+          isOpen={true}
+          onApprove={handleApprove}
+          onReject={handleReject}
+          onClose={() => setApprovalTarget(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/store/taskStore.ts
+++ b/frontend/src/store/taskStore.ts
@@ -5,6 +5,8 @@ type Task = {
   title: string;
   status: string;
   assignee: string;
+  approverID?: string;
+  rejectionReason?: string;
 };
 
 export function useTaskStore() {


### PR DESCRIPTION
Add task approval workflow with role-based permissions

## Purpose

Add an approval step to the task lifecycle so that completed work is reviewed
by a team lead or admin before being marked as done.

Closes #1

## User Story

As a team lead, I want to approve tasks before they move to "done" status,
so that completed work is reviewed before being marked as finished.

## Acceptance Criteria

- Tasks in "in_progress" status can be submitted for approval
- Only users with "lead" or "admin" role can approve tasks
- Approved tasks move to "done" status
- Rejected tasks return to "in_progress" with a rejection reason
- The approval dialog shows task details and allows approve/reject actions
- The rejection flow requires a mandatory reason field

## Non-Goals

- Email or Slack notifications for approval requests
- Bulk approval of multiple tasks at once
- Approval history or audit log

## QA Notes

- Test the approval flow with different user roles (viewer, editor, lead, admin)
- Verify state transitions cannot be skipped (e.g., draft -> pending_approval should fail)
- Check the approval dialog renders correctly and validates rejection reason
- Test concurrent approval/rejection scenarios
- Verify the "Submit for Approval" button only appears for in_progress tasks