### PR TITLE
Add StatusBadge size/icon support with Vitest tests

### DIFF
--- a/frontend/src/components/StatusBadge.stories.tsx
+++ b/frontend/src/components/StatusBadge.stories.tsx
@@ -4,6 +4,10 @@ import { StatusBadge } from "./StatusBadge";
 const meta: Meta<typeof StatusBadge> = {
   title: "Components/StatusBadge",
   component: StatusBadge,
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg"] },
+    showIcon: { control: "boolean" },
+  },
 };
 
 export default meta;
@@ -12,4 +16,23 @@ type Story = StoryObj<typeof StatusBadge>;
 export const Draft: Story = { args: { status: "draft" } };
 export const Open: Story = { args: { status: "open" } };
 export const InProgress: Story = { args: { status: "in_progress" } };
+export const Review: Story = { args: { status: "review" } };
+export const Approved: Story = { args: { status: "approved" } };
 export const Done: Story = { args: { status: "done" } };
+export const Rejected: Story = { args: { status: "rejected" } };
+
+export const WithIcon: Story = {
+  args: { status: "in_progress", showIcon: true },
+};
+
+export const Small: Story = {
+  args: { status: "open", size: "sm" },
+};
+
+export const Large: Story = {
+  args: { status: "done", size: "lg", showIcon: true },
+};
+
+export const UnknownStatus: Story = {
+  args: { status: "custom_status" },
+};

--- a/frontend/src/components/StatusBadge.test.tsx
+++ b/frontend/src/components/StatusBadge.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { StatusBadge } from "./StatusBadge";
+
+describe("StatusBadge", () => {
+  it("renders known status label", () => {
+    const badge = StatusBadge({ status: "open" });
+    expect(badge.props.children).toContain("Open");
+  });
+
+  it("falls back to raw status for unknown values", () => {
+    const badge = StatusBadge({ status: "custom" });
+    expect(badge.props.children).toContain("custom");
+  });
+
+  it("applies default medium size", () => {
+    const badge = StatusBadge({ status: "draft" });
+    expect(badge.props["data-size"]).toBe("md");
+  });
+
+  it("applies small size when specified", () => {
+    const badge = StatusBadge({ status: "draft", size: "sm" });
+    expect(badge.props["data-size"]).toBe("sm");
+  });
+
+  it("shows icon when showIcon is true", () => {
+    const badge = StatusBadge({ status: "done", showIcon: true });
+    const children = badge.props.children;
+    expect(children).toBeTruthy();
+  });
+
+  it("sets data-status attribute", () => {
+    const badge = StatusBadge({ status: "rejected" });
+    expect(badge.props["data-status"]).toBe("rejected");
+  });
+
+  it("uses fallback color for unknown status", () => {
+    const badge = StatusBadge({ status: "unknown" });
+    expect(badge.props.style.backgroundColor).toBe("#6b7280");
+  });
+});

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -2,35 +2,73 @@ import React from "react";
 
 type StatusBadgeProps = {
   status: string;
+  size?: "sm" | "md" | "lg";
+  showIcon?: boolean;
 };
 
 const statusLabels: Record<string, string> = {
   draft: "Draft",
   open: "Open",
   in_progress: "In Progress",
+  review: "In Review",
+  approved: "Approved",
   done: "Done",
+  rejected: "Rejected",
 };
 
 const statusColors: Record<string, string> = {
   draft: "#9ca3af",
   open: "#3b82f6",
   in_progress: "#f59e0b",
+  review: "#8b5cf6",
+  approved: "#10b981",
   done: "#10b981",
+  rejected: "#ef4444",
 };
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+const statusIcons: Record<string, string> = {
+  draft: "📝",
+  open: "📋",
+  in_progress: "🔄",
+  review: "👀",
+  approved: "✅",
+  done: "✅",
+  rejected: "❌",
+};
+
+const sizeStyles: Record<string, { padding: string; fontSize: string }> = {
+  sm: { padding: "1px 6px", fontSize: "10px" },
+  md: { padding: "2px 8px", fontSize: "12px" },
+  lg: { padding: "4px 12px", fontSize: "14px" },
+};
+
+export function StatusBadge({
+  status,
+  size = "md",
+  showIcon = false,
+}: StatusBadgeProps) {
+  const label = statusLabels[status] ?? status;
+  const icon = showIcon ? statusIcons[status] ?? "" : "";
+  const sizeStyle = sizeStyles[size] ?? sizeStyles.md;
+
   return (
     <span
       className="status-badge"
+      data-status={status}
+      data-size={size}
       style={{
         backgroundColor: statusColors[status] ?? "#6b7280",
         color: "white",
-        padding: "2px 8px",
+        padding: sizeStyle.padding,
         borderRadius: "4px",
-        fontSize: "12px",
+        fontSize: sizeStyle.fontSize,
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "4px",
       }}
     >
-      {statusLabels[status] ?? status}
+      {icon && <span aria-hidden="true">{icon}</span>}
+      {label}
     </span>
   );
 }


### PR DESCRIPTION
## User Story

As a task board user, I want to see status badges in different sizes and with icons, so that the task status is more visually distinctive across different views (compact list vs detail view).

## Acceptance Criteria

- [ ] StatusBadge supports sm/md/lg size props
- [ ] StatusBadge can display status-specific icons via showIcon prop
- [ ] New statuses (review, approved, rejected) are supported
- [ ] Unknown statuses fall back gracefully to raw value and default color
- [ ] Vitest unit tests cover all status variants and prop combinations
- [ ] Storybook stories updated with new variants

## Non-Goals

- No Playwright E2E tests for this component (no route changes involved)
- No backend changes
- No integration with task API

## QA Notes

- This is a pure frontend component change with Storybook + Vitest coverage
- Visual regression should be checked via Storybook stories
- No route or navigation changes — no E2E testing needed