### PR TITLE
Add task priority scoring with weighted factors

### DIFF
--- a/backend/domain/priority.go
+++ b/backend/domain/priority.go
@@ -1,0 +1,68 @@
+package domain
+
+import "time"
+
+// PriorityScore represents a calculated priority value for a task.
+type PriorityScore struct {
+	TaskID    string
+	Score     float64
+	Factors   []PriorityFactor
+	UpdatedAt time.Time
+}
+
+// PriorityFactor describes one component of the priority calculation.
+type PriorityFactor struct {
+	Name   string
+	Weight float64
+	Value  float64
+}
+
+// CalculatePriority computes a weighted priority score from task attributes.
+func CalculatePriority(urgency, impact, effort float64, isBlocking bool) PriorityScore {
+	factors := []PriorityFactor{
+		{Name: "urgency", Weight: 0.4, Value: clamp(urgency, 0, 10)},
+		{Name: "impact", Weight: 0.35, Value: clamp(impact, 0, 10)},
+		{Name: "effort_inverse", Weight: 0.25, Value: 10 - clamp(effort, 0, 10)},
+	}
+
+	score := 0.0
+	for _, f := range factors {
+		score += f.Weight * f.Value
+	}
+
+	if isBlocking {
+		score *= 1.5
+	}
+
+	if score > 10 {
+		score = 10
+	}
+
+	return PriorityScore{
+		Score:     score,
+		Factors:   factors,
+		UpdatedAt: time.Now(),
+	}
+}
+
+// ComparePriority returns negative if a < b, zero if equal, positive if a > b.
+func ComparePriority(a, b PriorityScore) int {
+	diff := a.Score - b.Score
+	if diff < -0.001 {
+		return -1
+	}
+	if diff > 0.001 {
+		return 1
+	}
+	return 0
+}
+
+func clamp(v, min, max float64) float64 {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}

--- a/backend/domain/priority_test.go
+++ b/backend/domain/priority_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import "testing"
+
+func TestCalculatePriority_Normal(t *testing.T) {
+	p := CalculatePriority(8, 7, 3, false)
+	if p.Score <= 0 {
+		t.Fatalf("expected positive score, got %f", p.Score)
+	}
+	if len(p.Factors) != 3 {
+		t.Fatalf("expected 3 factors, got %d", len(p.Factors))
+	}
+}
+
+func TestCalculatePriority_Blocking(t *testing.T) {
+	normal := CalculatePriority(5, 5, 5, false)
+	blocking := CalculatePriority(5, 5, 5, true)
+	if blocking.Score <= normal.Score {
+		t.Fatalf("blocking score (%f) should exceed normal (%f)", blocking.Score, normal.Score)
+	}
+}
+
+func TestCalculatePriority_Clamping(t *testing.T) {
+	p := CalculatePriority(-5, 15, 20, false)
+	if p.Score < 0 || p.Score > 10 {
+		t.Fatalf("score %f out of [0, 10] range", p.Score)
+	}
+}
+
+func TestComparePriority(t *testing.T) {
+	a := CalculatePriority(9, 8, 2, true)
+	b := CalculatePriority(3, 3, 8, false)
+	if ComparePriority(a, b) <= 0 {
+		t.Fatal("expected a > b")
+	}
+	if ComparePriority(b, a) >= 0 {
+		t.Fatal("expected b < a")
+	}
+}

--- a/backend/usecase/score_tasks.go
+++ b/backend/usecase/score_tasks.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"sort"
+
+	"github.com/hasesho05/shiftleft-qa-sample-app/backend/domain"
+)
+
+// TaskScoreInput holds the attributes needed for priority scoring.
+type TaskScoreInput struct {
+	TaskID     string
+	Urgency    float64
+	Impact     float64
+	Effort     float64
+	IsBlocking bool
+}
+
+// ScoreTasks calculates priority scores for a batch of tasks and returns them
+// sorted by score in descending order.
+func ScoreTasks(inputs []TaskScoreInput) []domain.PriorityScore {
+	scores := make([]domain.PriorityScore, 0, len(inputs))
+	for _, in := range inputs {
+		s := domain.CalculatePriority(in.Urgency, in.Impact, in.Effort, in.IsBlocking)
+		s.TaskID = in.TaskID
+		scores = append(scores, s)
+	}
+
+	sort.Slice(scores, func(i, j int) bool {
+		return domain.ComparePriority(scores[i], scores[j]) > 0
+	})
+
+	return scores
+}
+
+// TopN returns the top N highest-priority tasks.
+func TopN(scores []domain.PriorityScore, n int) []domain.PriorityScore {
+	if n >= len(scores) {
+		return scores
+	}
+	return scores[:n]
+}

--- a/backend/usecase/score_tasks_test.go
+++ b/backend/usecase/score_tasks_test.go
@@ -1,0 +1,42 @@
+package usecase
+
+import "testing"
+
+func TestScoreTasks_SortedDescending(t *testing.T) {
+	inputs := []TaskScoreInput{
+		{TaskID: "low", Urgency: 2, Impact: 2, Effort: 8, IsBlocking: false},
+		{TaskID: "high", Urgency: 9, Impact: 9, Effort: 2, IsBlocking: true},
+		{TaskID: "mid", Urgency: 5, Impact: 5, Effort: 5, IsBlocking: false},
+	}
+
+	scores := ScoreTasks(inputs)
+	if len(scores) != 3 {
+		t.Fatalf("expected 3 scores, got %d", len(scores))
+	}
+	if scores[0].TaskID != "high" {
+		t.Fatalf("expected 'high' first, got %s", scores[0].TaskID)
+	}
+	if scores[2].TaskID != "low" {
+		t.Fatalf("expected 'low' last, got %s", scores[2].TaskID)
+	}
+}
+
+func TestScoreTasks_Empty(t *testing.T) {
+	scores := ScoreTasks(nil)
+	if len(scores) != 0 {
+		t.Fatalf("expected empty, got %d", len(scores))
+	}
+}
+
+func TestTopN(t *testing.T) {
+	inputs := []TaskScoreInput{
+		{TaskID: "a", Urgency: 9, Impact: 9, Effort: 1, IsBlocking: true},
+		{TaskID: "b", Urgency: 5, Impact: 5, Effort: 5, IsBlocking: false},
+		{TaskID: "c", Urgency: 1, Impact: 1, Effort: 9, IsBlocking: false},
+	}
+	scores := ScoreTasks(inputs)
+	top := TopN(scores, 2)
+	if len(top) != 2 {
+		t.Fatalf("expected 2, got %d", len(top))
+	}
+}


### PR DESCRIPTION
## User Story

As a project manager, I want tasks to be automatically scored by priority based on urgency, impact, and effort, so that the team can focus on the most important work first.

## Acceptance Criteria

- [ ] CalculatePriority computes weighted score from urgency, impact, and effort
- [ ] Blocking tasks receive a 1.5x multiplier
- [ ] Input values are clamped to [0, 10] range
- [ ] ScoreTasks batch-processes multiple tasks and sorts by priority descending
- [ ] TopN returns the highest-priority subset
- [ ] All functions have Go test coverage

## Non-Goals

- No frontend changes
- No API endpoint (handler layer not touched)
- No database persistence (in-memory only)
- No visual or E2E testing needed

## QA Notes

- This is a pure backend domain + usecase change
- All logic is deterministic and covered by Go unit tests
- No frontend, Storybook, or Playwright involvement
- Edge cases to verify: clamping at boundaries, blocking multiplier cap at 10